### PR TITLE
Show debug info when Valid? is No

### DIFF
--- a/scanner/src/main/java/ca/on/oicr/gsi/runscanner/scanner/Configuration.java
+++ b/scanner/src/main/java/ca/on/oicr/gsi/runscanner/scanner/Configuration.java
@@ -39,6 +39,18 @@ public class Configuration {
         && timeZone != null;
   }
 
+  public String validitySummary() {
+    String summary = "";
+    if (path == null) summary += "Path is null! ";
+    if (!path.isDirectory()) summary += "Path is not a directory! ";
+    if (!path.canRead()) summary += "Path cannot be read! ";
+    if (!path.canExecute()) summary += "Path cannot be executed! ";
+    if (processor == null) summary += "Processor is null! ";
+    if (timeZone == null) summary += "TimeZone is null!";
+
+    return summary;
+  }
+
   public void setPath(File path) {
     this.path = path;
   }

--- a/scanner/src/main/java/ca/on/oicr/gsi/runscanner/scanner/UserInterfaceController.java
+++ b/scanner/src/main/java/ca/on/oicr/gsi/runscanner/scanner/UserInterfaceController.java
@@ -176,7 +176,11 @@ public class UserInterfaceController {
                               renderer.line("Processor", configuration.getProcessor().getName());
                               renderer.line(
                                   "Time Zone", configuration.getTimeZone().getDisplayName());
-                              renderer.line("Valid?", configuration.isValid() ? "Yes" : "No");
+                              renderer.line(
+                                  "Valid?",
+                                  configuration.isValid()
+                                      ? "Yes"
+                                      : "No: " + configuration.validitySummary());
                             }
                           }));
         }


### PR DESCRIPTION
No more attaching a debugger to isValid()! Only displays problems for simplicity.

Example output:
Valid? | No: Path is not a directory! Path cannot be read! Path cannot be executed!

